### PR TITLE
Write cloudfront URLs to markdown instead of s3 URLs

### DIFF
--- a/content_fetch/fetch_blog_posts.js
+++ b/content_fetch/fetch_blog_posts.js
@@ -17,11 +17,23 @@ var getBlogPosts = async function(lang) {
         out += "description: " + post.Description + "\n";
         out += "author: '" + post.AuthorAndTitle + "'\n";
         out += "date: '" + post.PublishDate + "'\n";
-        out += "image: " + post.BannerImage.url + "\n";
+        out += "image: " + post.BannerImage.url.replace(
+          "https://cds-website-assets-prod.s3.ca-central-1.amazonaws.com",
+          "https://de2an9clyit2x.cloudfront.net") + "\n";
         out += "image-alt: " + post.ImageAltText + "\n";
-        out += "thumb: " + post.BannerImage.formats.small.url + "\n";
+        out += "thumb: " + post.BannerImage.formats.small.url.replace(
+          "https://cds-website-assets-prod.s3.ca-central-1.amazonaws.com",
+          "https://de2an9clyit2x.cloudfront.net") + "\n";
         out += "translationKey: " + post.TranslationID + "\n";
         out += "---\n";
+
+        // sanitize any body image URLS to Cloudfront
+        while (post.Body.indexOf("https://cds-website-assets-prod.s3.ca-central-1.amazonaws.com") !== -1) {
+          post.Body = post.Body.replace(
+            "https://cds-website-assets-prod.s3.ca-central-1.amazonaws.com",
+            "https://de2an9clyit2x.cloudfront.net");
+        }
+
         out += post.Body + "\n";
         
         let slug = buildFileName(post.Title);

--- a/content_fetch/fetch_blog_posts.js
+++ b/content_fetch/fetch_blog_posts.js
@@ -17,6 +17,9 @@ var getBlogPosts = async function(lang) {
         out += "description: " + post.Description + "\n";
         out += "author: '" + post.AuthorAndTitle + "'\n";
         out += "date: '" + post.PublishDate + "'\n";
+
+        // Strapi can only interface with the S3 URLS for the images, so we need to convert them to
+        // Cloudfront so they will be externally visible
         out += "image: " + post.BannerImage.url.replace(
           "https://cds-website-assets-prod.s3.ca-central-1.amazonaws.com",
           "https://de2an9clyit2x.cloudfront.net") + "\n";
@@ -27,7 +30,7 @@ var getBlogPosts = async function(lang) {
         out += "translationKey: " + post.TranslationID + "\n";
         out += "---\n";
 
-        // sanitize any body image URLS to Cloudfront
+        // Convert any body image URLS to Cloudfront
         while (post.Body.indexOf("https://cds-website-assets-prod.s3.ca-central-1.amazonaws.com") !== -1) {
           post.Body = post.Body.replace(
             "https://cds-website-assets-prod.s3.ca-central-1.amazonaws.com",

--- a/dist/index.js
+++ b/dist/index.js
@@ -24,11 +24,23 @@ var getBlogPosts = async function(lang) {
         out += "description: " + post.Description + "\n";
         out += "author: '" + post.AuthorAndTitle + "'\n";
         out += "date: '" + post.PublishDate + "'\n";
-        out += "image: " + post.BannerImage.url + "\n";
+        out += "image: " + post.BannerImage.url.replace(
+          "https://cds-website-assets-prod.s3.ca-central-1.amazonaws.com",
+          "https://de2an9clyit2x.cloudfront.net") + "\n";
         out += "image-alt: " + post.ImageAltText + "\n";
-        out += "thumb: " + post.BannerImage.formats.small.url + "\n";
+        out += "thumb: " + post.BannerImage.formats.small.url.replace(
+          "https://cds-website-assets-prod.s3.ca-central-1.amazonaws.com",
+          "https://de2an9clyit2x.cloudfront.net") + "\n";
         out += "translationKey: " + post.TranslationID + "\n";
         out += "---\n";
+
+        // sanitize any body image URLS to Cloudfront
+        while (post.Body.indexOf("https://cds-website-assets-prod.s3.ca-central-1.amazonaws.com") !== -1) {
+          post.Body = post.Body.replace(
+            "https://cds-website-assets-prod.s3.ca-central-1.amazonaws.com",
+            "https://de2an9clyit2x.cloudfront.net");
+        }
+
         out += post.Body + "\n";
         
         let slug = buildFileName(post.Title);
@@ -284,6 +296,7 @@ const createAndUpdateFiles = async (newFiles, oldFiles, lang, subpath, branchNam
     // === if file new or modified code here! ====
     // If single file, github returns an object instead of an array
     var exists = (oldFiles.name && oldFiles.name == newFiles[f].fileName) ? [oldFiles] : oldFiles.filter(oldFile => oldFile.path == subpath + newFiles[f].fileName);
+
     let content = Base64.encode(newFiles[f].body)
 
     if (exists.length == 0) {
@@ -320,7 +333,7 @@ const createAndUpdateFiles = async (newFiles, oldFiles, lang, subpath, branchNam
 }
 
 const updateTeamFile = async (newFile, branchName) => {
-  console.log(newFile)
+
   let content = Base64.encode(newFile[0].body)
   await octokit.repos.getContent({
     owner: 'cds-snc',
@@ -358,18 +371,23 @@ async function run() {
     Existing Content from the repo
   */
 
-  // get content tree(s)
+  // get content tree(s) shas
+  let treeShas = await octokit.repos.getContent({
+    owner: 'cds-snc',
+    repo: 'digital-canada-ca',
+    path: "/content",
+  });
   
   let existingContentEN = await octokit.git.getTree({
     owner: 'cds-snc',
     repo: 'digital-canada-ca',
-    tree_sha: "3cfb5d4cc05fe6a76d359950625dcdf7bb65cb09",
+    tree_sha: treeShas.data.filter(tree => tree.name == "en")[0].sha, // filter by name in case this directory is ever modified / added to
     recursive: true
   });
   let existingContentFR = await octokit.git.getTree({
     owner: 'cds-snc',
     repo: 'digital-canada-ca',
-    tree_sha: "4fda37ecfae0cadc3039d0ad3203f4761c3aad6d",
+    tree_sha: treeShas.data.filter(tree => tree.name == "fr")[0].sha,
     recursive: true
   });
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -381,13 +381,13 @@ async function run() {
   let existingContentEN = await octokit.git.getTree({
     owner: 'cds-snc',
     repo: 'digital-canada-ca',
-    tree_sha: treeShas.data.filter(tree => tree.name == "en")[0].sha, // filter by name in case this directory is ever modified / added to
+    tree_sha: treeShas.data.filter(tree => tree.name === "en")[0].sha, // filter by name in case this directory is ever modified / added to
     recursive: true
   });
   let existingContentFR = await octokit.git.getTree({
     owner: 'cds-snc',
     repo: 'digital-canada-ca',
-    tree_sha: treeShas.data.filter(tree => tree.name == "fr")[0].sha,
+    tree_sha: treeShas.data.filter(tree => tree.name === "fr")[0].sha,
     recursive: true
   });
 

--- a/index.js
+++ b/index.js
@@ -149,13 +149,13 @@ async function run() {
   let existingContentEN = await octokit.git.getTree({
     owner: 'cds-snc',
     repo: 'digital-canada-ca',
-    tree_sha: treeShas.data.filter(tree => tree.name == "en")[0].sha, // filter by name in case this directory is ever modified / added to
+    tree_sha: treeShas.data.filter(tree => tree.name === "en")[0].sha, // filter by name in case this directory is ever modified / added to
     recursive: true
   });
   let existingContentFR = await octokit.git.getTree({
     owner: 'cds-snc',
     repo: 'digital-canada-ca',
-    tree_sha: treeShas.data.filter(tree => tree.name == "fr")[0].sha,
+    tree_sha: treeShas.data.filter(tree => tree.name === "fr")[0].sha,
     recursive: true
   });
 

--- a/index.js
+++ b/index.js
@@ -64,6 +64,7 @@ const createAndUpdateFiles = async (newFiles, oldFiles, lang, subpath, branchNam
     // === if file new or modified code here! ====
     // If single file, github returns an object instead of an array
     var exists = (oldFiles.name && oldFiles.name == newFiles[f].fileName) ? [oldFiles] : oldFiles.filter(oldFile => oldFile.path == subpath + newFiles[f].fileName);
+
     let content = Base64.encode(newFiles[f].body)
 
     if (exists.length == 0) {
@@ -100,7 +101,7 @@ const createAndUpdateFiles = async (newFiles, oldFiles, lang, subpath, branchNam
 }
 
 const updateTeamFile = async (newFile, branchName) => {
-  console.log(newFile)
+
   let content = Base64.encode(newFile[0].body)
   await octokit.repos.getContent({
     owner: 'cds-snc',
@@ -138,18 +139,23 @@ async function run() {
     Existing Content from the repo
   */
 
-  // get content tree(s)
+  // get content tree(s) shas
+  let treeShas = await octokit.repos.getContent({
+    owner: 'cds-snc',
+    repo: 'digital-canada-ca',
+    path: "/content",
+  });
   
   let existingContentEN = await octokit.git.getTree({
     owner: 'cds-snc',
     repo: 'digital-canada-ca',
-    tree_sha: "3cfb5d4cc05fe6a76d359950625dcdf7bb65cb09",
+    tree_sha: treeShas.data.filter(tree => tree.name == "en")[0].sha, // filter by name in case this directory is ever modified / added to
     recursive: true
   });
   let existingContentFR = await octokit.git.getTree({
     owner: 'cds-snc',
     repo: 'digital-canada-ca',
-    tree_sha: "4fda37ecfae0cadc3039d0ad3203f4761c3aad6d",
+    tree_sha: treeShas.data.filter(tree => tree.name == "fr")[0].sha,
     recursive: true
   });
 


### PR DESCRIPTION
This will allow us to secure the s3 bucket, without having to maintain a fork of strapi's s3 provider.

This PR also fixes a major bug where tree shas were hard coded.

Closes: https://github.com/cds-snc/cds-website-cms/issues/7


Test PR from running this code: https://github.com/cds-snc/digital-canada-ca/pull/2055
Only 3 files because currently only those files have been migrated to Strapi. I will manually replace the rest and use the cloudfront url going forward in the migration.