### PR TITLE
reverting team members fetch for now

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const getBlogPostsFromGCArticles = require("./content_fetch/fetch_gc_articles_bl
 
 const getJobPostsFromGCArticles = require("./content_fetch/fetch_gc_articles_job_posts");
 
-const getTeamMembersFromGCArticles = require("./content_fetch/fetch_gc_articles_team_members");
+// const getTeamMembersFromGCArticles = require("./content_fetch/fetch_gc_articles_team_members");
 
 
 async function closePRs() {
@@ -215,7 +215,7 @@ async function run() {
   var gcArticlesJobPostsFr = await getJobPostsFromGCArticles("fr");
 
   //GC Articles Team members
-  var gcArticlesTeamMembers = await getTeamMembersFromGCArticles();
+  // var gcArticlesTeamMembers = await getTeamMembersFromGCArticles();
 
   // Create Ref
   const websiteSha = await getHeadSha("digital-canada-ca", "main");
@@ -254,7 +254,7 @@ async function run() {
 
   // Team Members
   await updateTeamFile(teamMembersNew, branchName);
-  await updateTeamFile(gcArticlesTeamMembers, branchName);
+  // await updateTeamFile(gcArticlesTeamMembers, branchName);
 
   //Product Suite
   await createAndUpdateFiles(productSuiteEnNew, existingContentEN.data.tree, "en", "product-suite/product/", branchName);


### PR DESCRIPTION
# Summary | Résumé

Since GC Articles has no team members, it updates the team.yml to no team members. Causes issues when trying to post, fixing it.