### PR TITLE
chore: update to new Strapi URL and HTTPS

### DIFF
--- a/.github/workflows/strapi-update.yml
+++ b/.github/workflows/strapi-update.yml
@@ -7,6 +7,6 @@ jobs:
     - uses: cds-snc/cds-website-pr-bot@main
       env:
         TOKEN: ${{ secrets.TOKEN }}
-        STRAPI_ENDPOINT: http://cms-load-balancer-986685684.ca-central-1.elb.amazonaws.com/
+        STRAPI_ENDPOINT: https://strapi.cdssandbox.xyz/
         GC_ARTICLES_ENDPOINT_EN: https://articles.alpha.canada.ca/cds-snc/wp-json/wp/v2/
         GC_ARTICLES_ENDPOINT_FR: https://articles.alpha.canada.ca/cds-snc/fr/wp-json/wp/v2/


### PR DESCRIPTION
# Summary
Update the Strapi workflow to use the new CMS URL.

# Related
- https://github.com/cds-snc/cds-website-terraform/pull/45
- https://github.com/cds-snc/platform-core-services/issues/471