### PR TITLE
Changing the token from a PAT token to GITHUB_TOKEN

### DIFF
--- a/.github/workflows/strapi-update.yml
+++ b/.github/workflows/strapi-update.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
     - uses: cds-snc/cds-website-pr-bot@main
       env:
-        TOKEN: ${{ secrets.TOKEN }}
+        TOKEN: ${{ secrets.GITHUB_TOKEN }}
         STRAPI_ENDPOINT: https://strapi.cdssandbox.xyz/
         GC_ARTICLES_ENDPOINT_EN: https://articles.alpha.canada.ca/cds-snc/wp-json/wp/v2/
         GC_ARTICLES_ENDPOINT_FR: https://articles.alpha.canada.ca/cds-snc/fr/wp-json/wp/v2/


### PR DESCRIPTION
# Summary | Résumé

Changing the token to be used in the workflow from Max's personal access token to GITHUB_TOKEN. 