### PR TITLE
chore:  switch to CDS Release Bot

### DIFF
--- a/.github/workflows/strapi-update.yml
+++ b/.github/workflows/strapi-update.yml
@@ -8,8 +8,8 @@ jobs:
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
         id: generate_token
         with:
-          app_id: ${{ secrets.SRE_BOT_RW_APP_ID }}
-          private_key: ${{ secrets.SRE_BOT_RW_PRIVATE_KEY}}
+          app-id: ${{ secrets.CDS_RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.CDS_RELEASE_BOT_PRIVATE_KEY }}
 
       - name: Generate a PR
         uses: cds-snc/cds-website-pr-bot@main


### PR DESCRIPTION
# Summary
Update the release please workflow to use a new, dedicated GitHub app for releases.

# Related
- https://github.com/cds-snc/platform-core-services/issues/707